### PR TITLE
Implement fence_matsubara_sampling and complete spir_uhat_get_default_matsus

### DIFF
--- a/sparseir-capi/include/sparseir.h
+++ b/sparseir-capi/include/sparseir.h
@@ -885,6 +885,13 @@ int spir_funcs_batch_eval_matsu(const struct spir_funcs *funcs,
  * a spir_funcs object that represents Matsubara-space basis functions (e.g., uhat or uhat_full).
  * The statistics type (Fermionic/Bosonic) is automatically detected from the spir_funcs object type.
  *
+ * This extracts the PiecewiseLegendreFTVector from spir_funcs and calls
+ * `FiniteTempBasis::default_matsubara_sampling_points_impl` from `basis.rs` (lines 332-387)
+ * to compute default sampling points.
+ *
+ * The implementation uses the same algorithm as defined in `sparseir-rust/src/basis.rs`,
+ * which selects sampling points based on sign changes or extrema of the Matsubara basis functions.
+ *
  * # Arguments
  * * `uhat` - Pointer to a spir_funcs object representing Matsubara-space basis functions
  * * `l` - Number of requested sampling points


### PR DESCRIPTION
## Summary

This PR implements the `fence_matsubara_sampling` function and completes the `spir_uhat_get_default_matsus` implementation.

## Changes

### 1. Implement `fence_matsubara_sampling` function (`sparseir-rust/src/basis.rs`)
   - Matches C++ implementation in `basis.hpp` (lines 407-452)
   - Adds additional sampling points near outer frequencies to improve conditioning
   - Supports both Fermionic and Bosonic statistics
   - The function adds oversampling points when the number of sampling points is >= 20 or >= 42

### 2. Complete `spir_uhat_get_default_matsus` implementation (`sparseir-capi/src/funcs.rs`)
   - Consolidate helper function into main function
   - Use `FiniteTempBasis::default_matsubara_sampling_points_impl` from `basis.rs`
   - Properly handle `fence` parameter (mitigate) for conditioning improvement
   - Implementation now directly calls the basis function from `basis.rs` (lines 332-387)

### 3. Update `default_matsubara_sampling_points_impl` (`sparseir-rust/src/basis.rs`)
   - Change `_fence` parameter to `fence` and actually use it
   - Call `fence_matsubara_sampling` when `fence=true`

## Technical Details

The `fence_matsubara_sampling` function improves the conditioning of Matsubara sampling matrices by:
- Adding sampling points at outer frequencies ± 2.5% of the outer frequency value
- Ensuring the added frequencies are valid for the statistics type (odd for Fermionic, even for Bosonic)
- Sorting and removing duplicates after adding the fence points

This matches the C++ reference implementation behavior.

## Testing

- All code compiles successfully
- Implementation follows the same algorithm as the C++ version
- Both Fermionic and Bosonic cases are handled correctly