### PR TITLE
Add version consistency check to all GitHub Actions workflows (bump to v0.7.2)

### DIFF
--- a/.github/workflows/cxx_tests.yml
+++ b/.github/workflows/cxx_tests.yml
@@ -19,6 +19,8 @@ jobs:
       with:
         submodules: false
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Check version consistency
+      run: python3 check_version.py
     - name: Initialize and update submodules
       run: |
         # Convert SSH URLs to HTTPS for GitHub Actions
@@ -40,6 +42,8 @@ jobs:
       with:
         submodules: false
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Check version consistency
+      run: python3 check_version.py
     - name: Install OpenBLAS
       run: |
         sudo apt-get update
@@ -65,6 +69,8 @@ jobs:
       with:
         submodules: false
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Check version consistency
+      run: python3 check_version.py
     - name: Install OpenBLAS with ILP64
       run: |
         sudo apt-get update

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,9 @@ jobs:
           submodules: false
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check version consistency
+        run: python3 check_version.py
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -43,6 +46,9 @@ jobs:
         with:
           submodules: false
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check version consistency
+        run: python3 check_version.py
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust_capi.yml
+++ b/.github/workflows/rust_capi.yml
@@ -19,6 +19,8 @@ jobs:
       with:
         submodules: false
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Check version consistency
+      run: python3 check_version.py
     - name: Install OpenBLAS
       run: |
         sudo apt-get update

--- a/.github/workflows/test_fortran.yml
+++ b/.github/workflows/test_fortran.yml
@@ -21,6 +21,9 @@ jobs:
           submodules: false
           token: ${{ secrets.GITHUB_TOKEN }}
       
+      - name: Check version consistency
+        run: python3 check_version.py
+      
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       
@@ -50,6 +53,9 @@ jobs:
         with:
           submodules: false
           token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Check version consistency
+        run: python3 check_version.py
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
- Bump to v0.7.2
- Add python3 check_version.py step to all workflow jobs
- Ensures version consistency is verified before any build/test steps
- Applied to:
  - rust.yml (2 jobs: rust-default, rust-system-blas)
  - rust_capi.yml (1 job)
  - test_fortran.yml (2 jobs: test-fortran-gcc, test-fortran-intel)
  - cxx_tests.yml (3 jobs: test-default-backend, test-openblas, test-openblas-ilp64)