### PR TITLE
test: add cfg attribute to test_default_backend_is_faer

### DIFF
--- a/sparse-ir/src/gemm.rs
+++ b/sparse-ir/src/gemm.rs
@@ -1008,6 +1008,7 @@ mod tests {
     use mdarray::DView;
 
     #[test]
+    #[cfg(not(feature = "system-blas"))]
     fn test_default_backend_is_faer() {
         let (name, is_external, is_ilp64) = get_backend_info();
         assert_eq!(name, "Faer (Pure Rust)");


### PR DESCRIPTION
## Summary

This PR adds a conditional compilation attribute to `test_default_backend_is_faer` to ensure it only runs when `blas-sys` is not used.

## Changes

- **Add `#[cfg(not(feature = "system-blas"))]` to `test_default_backend_is_faer`**
  - This test verifies that the default backend is Faer (Pure Rust)
  - When `system-blas` feature is enabled, the backend is BLAS, not Faer
  - Therefore, this test should only run when `system-blas` is disabled

## Testing

- Test passes when `system-blas` feature is disabled
- Test is correctly skipped (0 tests) when `system-blas` feature is enabled