### PR TITLE
Implement condition number calculation for sampling matrices using SVD

### DIFF
--- a/sparse-ir-capi/Cargo.toml
+++ b/sparse-ir-capi/Cargo.toml
@@ -26,6 +26,10 @@ sparse-ir.workspace = true
 # Array library (for Shape trait)
 mdarray.workspace = true
 
+# Linear algebra for SVD computation (condition number)
+mdarray-linalg.workspace = true
+mdarray-linalg-faer.workspace = true
+
 # Error code type
 libc.workspace = true
 

--- a/sparse-ir/src/matsubara_sampling.rs
+++ b/sparse-ir/src/matsubara_sampling.rs
@@ -152,6 +152,11 @@ impl<S: StatisticsType> MatsubaraSampling<S> {
         self.fitter.basis_size()
     }
 
+    /// Get the sampling matrix
+    pub fn matrix(&self) -> &DTensor<Complex<f64>, 2> {
+        &self.fitter.matrix
+    }
+
     /// Evaluate complex basis coefficients at sampling points
     ///
     /// # Arguments
@@ -623,6 +628,11 @@ impl<S: StatisticsType> MatsubaraSamplingPositiveOnly<S> {
     /// Basis size
     pub fn basis_size(&self) -> usize {
         self.fitter.basis_size()
+    }
+
+    /// Get the original complex sampling matrix
+    pub fn matrix(&self) -> &DTensor<Complex<f64>, 2> {
+        &self.fitter.matrix
     }
 
     /// Evaluate basis coefficients at sampling points


### PR DESCRIPTION
- Added functions to compute the condition number for both real and complex matrices.
- Updated `spir_sampling_get_cond_num` to calculate the condition number based on the sampling matrix type.
- Introduced matrix retrieval methods in `MatsubaraSampling` and `MatsubaraSamplingPositiveOnly` for accessing the underlying sampling matrices.
- Updated Cargo.toml to include dependencies for linear algebra operations required for SVD computation.