### PR TITLE
feat: enable system BLAS for C API benchmarks

### DIFF
--- a/capi_benchmark/run_with_rust_capi.sh
+++ b/capi_benchmark/run_with_rust_capi.sh
@@ -38,8 +38,8 @@ fi
 # Step 1: Build Rust C API library
 echo -e "${YELLOW}Step 1: Building sparseir-capi...${NC}"
 
-# Build release version with shared library
-cargo build --release -p sparse-ir-capi
+# Build release version with shared library (using system BLAS for better performance)
+cargo build --release -p sparse-ir-capi --features system-blas
 
 # Determine library extension based on OS
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/sparse-ir-capi/Cargo.toml
+++ b/sparse-ir-capi/Cargo.toml
@@ -43,6 +43,8 @@ paste = "1.0"
 [features]
 default = []
 capi = []
+# Use system BLAS for GEMM backend
+system-blas = ["sparse-ir/system-blas"]
 
 # cargo-c configuration for cinstall
 [package.metadata.capi]


### PR DESCRIPTION
## Summary
- Add `system-blas` feature to `sparse-ir-capi` that propagates to `sparse-ir`
- Update `run_with_rust_capi.sh` to build with `--features system-blas`
- Uses macOS Accelerate or system BLAS instead of pure Rust Faer backend for better performance

## Test plan
- [x] `cargo build --release -p sparse-ir-capi --features system-blas` builds successfully
- [x] Benchmark script runs with system BLAS enabled