### PR TITLE
feat(python): use SciPy BLAS backend for fit/evaluate operations

### DIFF
--- a/python/tests/c_api/dlr_tests.py
+++ b/python/tests/c_api/dlr_tests.py
@@ -12,6 +12,7 @@ from ctypes import c_int, c_double, byref, POINTER
 
 from pylibsparseir.core import (
     _lib,
+    _blas_backend,
     logistic_kernel_new, reg_bose_kernel_new,
     sve_result_new, basis_new,
     COMPUTATION_SUCCESS, c_double_complex
@@ -222,7 +223,7 @@ class TestDLRTransformations:
 
             convert_status = _lib.spir_dlr2ir_dd(
                 dlr,
-                None,  # Use default backend (null pointer)
+                _blas_backend,  # Use SciPy BLAS backend
                 SPIR_ORDER_ROW_MAJOR,
                 ndim,
                 dims.ctypes.data_as(POINTER(c_int)),
@@ -294,7 +295,7 @@ class TestDLRTransformations:
 
                 convert_status = _lib.spir_dlr2ir_dd(
                     dlr,
-                    None,  # Use default backend (null pointer)
+                    _blas_backend,  # Use SciPy BLAS backend
                     SPIR_ORDER_ROW_MAJOR,
                     ndim,
                     dims.ctypes.data_as(POINTER(c_int)),
@@ -357,7 +358,7 @@ class TestDLRTransformations:
 
             convert_status = _lib.spir_dlr2ir_zz(
                 dlr,
-                None,  # Use default backend (null pointer)
+                _blas_backend,  # Use SciPy BLAS backend
                 SPIR_ORDER_ROW_MAJOR,
                 ndim,
                 dims.ctypes.data_as(POINTER(c_int)),

--- a/python/tests/c_api/integration_tests.py
+++ b/python/tests/c_api/integration_tests.py
@@ -13,6 +13,7 @@ from ctypes import c_int, c_double, c_bool, byref, POINTER
 
 from pylibsparseir.core import (
     _lib,
+    _blas_backend,
     logistic_kernel_new, reg_bose_kernel_new,
     sve_result_new, basis_new,
     tau_sampling_new, matsubara_sampling_new,
@@ -204,7 +205,7 @@ class TestIntegrationWorkflow:
         # DLR to IR
         status = _lib.spir_dlr2ir_dd(
             dlr,
-            None,  # Use default backend (null pointer)
+            _blas_backend,  # Use SciPy BLAS backend
             SPIR_ORDER_ROW_MAJOR,
             ndim,
             dlr_dims.ctypes.data_as(POINTER(c_int)),
@@ -242,7 +243,7 @@ class TestIntegrationWorkflow:
         ir_coeffs_from_dlr = np.zeros(ir_size, dtype=np.float64)
         status = _lib.spir_dlr2ir_dd(
             dlr,
-            None,  # Use default backend (null pointer)
+            _blas_backend,  # Use SciPy BLAS backend
             SPIR_ORDER_ROW_MAJOR,
             1,
             np.array([n_poles], dtype=np.int32).ctypes.data_as(POINTER(c_int)),
@@ -256,7 +257,7 @@ class TestIntegrationWorkflow:
         ir_tau_values = np.zeros(n_tau_points, dtype=np.float64)
         status = _lib.spir_sampling_eval_dd(
             ir_tau_sampling,
-            None,  # Use default backend
+            _blas_backend,  # Use SciPy BLAS backend
             SPIR_ORDER_ROW_MAJOR,
             1,
             np.array([ir_size], dtype=np.int32).ctypes.data_as(POINTER(c_int)),
@@ -270,7 +271,7 @@ class TestIntegrationWorkflow:
         dlr_tau_values = np.zeros(n_tau_points, dtype=np.float64)
         status = _lib.spir_sampling_eval_dd(
             dlr_tau_sampling,
-            None,  # Use default backend
+            _blas_backend,  # Use SciPy BLAS backend
             SPIR_ORDER_ROW_MAJOR,
             1,
             np.array([n_poles], dtype=np.int32).ctypes.data_as(POINTER(c_int)),
@@ -356,7 +357,7 @@ class TestIntegrationMultiDimensional:
 
         status = _lib.spir_dlr2ir_dd(
             dlr,
-            None,  # Use default backend (null pointer)
+            _blas_backend,  # Use SciPy BLAS backend
             SPIR_ORDER_ROW_MAJOR,
             3,
             np.array(dlr_dims, dtype=np.int32).ctypes.data_as(POINTER(c_int)),
@@ -407,7 +408,7 @@ class TestIntegrationErrorHandling:
             # This may or may not fail depending on C implementation robustness
             status = _lib.spir_dlr2ir_dd(
                 dlr,
-                None,  # Use default backend (null pointer)
+                _blas_backend,  # Use SciPy BLAS backend
                 SPIR_ORDER_ROW_MAJOR,
                 1,
                 wrong_dims.ctypes.data_as(POINTER(c_int)),
@@ -615,7 +616,7 @@ class TestEnhancedDLRSamplingIntegration:
             # Convert DLR to IR
             ir_coeffs = np.zeros(ir_size.value, dtype=np.float64)
             status = _lib.spir_dlr2ir_dd(
-                dlr, None, SPIR_ORDER_ROW_MAJOR, 1,  # Use default backend (null pointer)
+                dlr, _blas_backend, SPIR_ORDER_ROW_MAJOR, 1,  # Use SciPy BLAS backend
                 np.array([n_poles.value], dtype=np.int32).ctypes.data_as(POINTER(c_int)),
                 0,
                 dlr_coeffs.ctypes.data_as(POINTER(c_double)),
@@ -658,7 +659,7 @@ class TestEnhancedDLRSamplingIntegration:
             # Test using C API sampling evaluation
             gtau_from_dlr_sampling = np.zeros(n_tau_points.value, dtype=np.float64)
             status = _lib.spir_sampling_eval_dd(
-                dlr_tau_sampling, None, SPIR_ORDER_ROW_MAJOR, 1,  # Use default backend
+                dlr_tau_sampling, _blas_backend, SPIR_ORDER_ROW_MAJOR, 1,  # Use SciPy BLAS backend
                 np.array([n_poles.value], dtype=np.int32).ctypes.data_as(POINTER(c_int)),
                 0,
                 dlr_coeffs.ctypes.data_as(POINTER(c_double)),
@@ -729,7 +730,7 @@ class TestEnhancedDLRSamplingIntegration:
             # Convert DLR to IR for 2D case
             ir_coeffs_2d = np.zeros(ir_size.value * d1, dtype=np.float64)
             status = _lib.spir_dlr2ir_dd(
-                dlr, None, SPIR_ORDER_ROW_MAJOR, 2,  # Use default backend (null pointer)
+                dlr, _blas_backend, SPIR_ORDER_ROW_MAJOR, 2,  # Use SciPy BLAS backend
                 np.array(dims_dlr, dtype=np.int32).ctypes.data_as(POINTER(c_int)),
                 0,
                 dlr_coeffs_2d.ctypes.data_as(POINTER(c_double)),

--- a/python/tests/c_api/sampling_tests.py
+++ b/python/tests/c_api/sampling_tests.py
@@ -12,6 +12,7 @@ from ctypes import c_int, c_double, c_bool, byref, POINTER
 
 from pylibsparseir.core import (
     _lib,
+    _blas_backend,
     logistic_kernel_new, reg_bose_kernel_new,
     sve_result_new, basis_new,
     c_double_complex,
@@ -244,7 +245,7 @@ class TestSamplingEvaluation1D:
         # Evaluate using C API
         evaluate_status = _lib.spir_sampling_eval_dd(
             sampling,
-            None,  # Use default backend
+            _blas_backend,  # Use SciPy BLAS backend
             SPIR_ORDER_ROW_MAJOR,
             ndim,
             dims.ctypes.data_as(POINTER(c_int)),
@@ -257,7 +258,7 @@ class TestSamplingEvaluation1D:
         # Fit back to coefficients
         fit_status = _lib.spir_sampling_fit_dd(
             sampling,
-            None,  # Use default backend
+            _blas_backend,  # Use SciPy BLAS backend
             SPIR_ORDER_ROW_MAJOR,
             ndim,
             dims.ctypes.data_as(POINTER(c_int)),
@@ -344,7 +345,7 @@ class TestSamplingEvaluationMultiD:
             # Evaluate using C API
             evaluate_status = _lib.spir_sampling_eval_dd(
                 sampling,
-                None,  # Use default backend
+                _blas_backend,  # Use SciPy BLAS backend
                 SPIR_ORDER_ROW_MAJOR,
                 ndim,
                 dims.ctypes.data_as(POINTER(c_int)),
@@ -357,7 +358,7 @@ class TestSamplingEvaluationMultiD:
             # Fit back to coefficients
             fit_status = _lib.spir_sampling_fit_dd(
                 sampling,
-                None,  # Use default backend
+                _blas_backend,  # Use SciPy BLAS backend
                 SPIR_ORDER_ROW_MAJOR,
                 ndim,
                 dims.ctypes.data_as(POINTER(c_int)),
@@ -441,7 +442,7 @@ class TestSamplingEvaluationComplex:
         evaluate_dims = np.array([basis_size.value], dtype=np.int32)
         evaluate_status = _lib.spir_sampling_eval_zz(
             sampling,
-            None,  # Use default backend
+            _blas_backend,  # Use SciPy BLAS backend
             SPIR_ORDER_ROW_MAJOR,
             ndim,
             evaluate_dims.ctypes.data_as(POINTER(c_int)),
@@ -455,7 +456,7 @@ class TestSamplingEvaluationComplex:
         fit_dims = np.array([actual_n_points.value], dtype=np.int32)
         fit_status = _lib.spir_sampling_fit_zz(
             sampling,
-            None,  # Use default backend
+            _blas_backend,  # Use SciPy BLAS backend
             SPIR_ORDER_ROW_MAJOR,
             ndim,
             fit_dims.ctypes.data_as(POINTER(c_int)),
@@ -552,7 +553,7 @@ class TestAdvanced4DComplexSampling:
             evaluate_output = np.zeros(output_total_size * 2, dtype=np.float64)
             evaluate_status = _lib.spir_sampling_eval_zz(
                 sampling,
-                None,  # Use default backend
+                _blas_backend,  # Use SciPy BLAS backend
                 SPIR_ORDER_ROW_MAJOR,
                 ndim,
                 np.array(dims, dtype=np.int32).ctypes.data_as(POINTER(c_int)),
@@ -566,7 +567,7 @@ class TestAdvanced4DComplexSampling:
             fit_output = np.zeros(total_size * 2, dtype=np.float64)
             fit_status = _lib.spir_sampling_fit_zz(
                 sampling,
-                None,  # Use default backend
+                _blas_backend,  # Use SciPy BLAS backend
                 SPIR_ORDER_ROW_MAJOR,
                 ndim,
                 np.array(output_dims, dtype=np.int32).ctypes.data_as(POINTER(c_int)),
@@ -653,7 +654,7 @@ class TestAdvanced4DComplexSampling:
             evaluate_output = np.zeros(output_total_size * 2, dtype=np.float64)
             evaluate_status = _lib.spir_sampling_eval_zz(
                 sampling,
-                None,  # Use default backend
+                _blas_backend,  # Use SciPy BLAS backend
                 SPIR_ORDER_ROW_MAJOR,
                 ndim,
                 np.array(dims, dtype=np.int32).ctypes.data_as(POINTER(c_int)),
@@ -667,7 +668,7 @@ class TestAdvanced4DComplexSampling:
             fit_output = np.zeros(total_size * 2, dtype=np.float64)
             fit_status = _lib.spir_sampling_fit_zz(
                 sampling,
-                None,  # Use default backend
+                _blas_backend,  # Use SciPy BLAS backend
                 SPIR_ORDER_ROW_MAJOR,
                 ndim,
                 np.array(output_dims, dtype=np.int32).ctypes.data_as(POINTER(c_int)),
@@ -744,7 +745,7 @@ class TestAdvanced4DComplexSampling:
             evaluate_output = np.zeros(output_total_size, dtype=np.float64)
             evaluate_status = _lib.spir_sampling_eval_dd(
                 sampling,
-                None,  # Use default backend
+                _blas_backend,  # Use SciPy BLAS backend
                 SPIR_ORDER_ROW_MAJOR,
                 ndim,
                 np.array(dims, dtype=np.int32).ctypes.data_as(POINTER(c_int)),
@@ -758,7 +759,7 @@ class TestAdvanced4DComplexSampling:
             fit_output = np.zeros(total_size, dtype=np.float64)
             fit_status = _lib.spir_sampling_fit_dd(
                 sampling,
-                None,  # Use default backend
+                _blas_backend,  # Use SciPy BLAS backend
                 SPIR_ORDER_ROW_MAJOR,
                 ndim,
                 np.array(output_dims, dtype=np.int32).ctypes.data_as(POINTER(c_int)),


### PR DESCRIPTION
Replace all None backend parameters with _blas_backend in test files:
- sampling_tests.py: 12 occurrences
- dlr_tests.py: 3 occurrences
- integration_tests.py: 9 occurrences

This uses SciPy's BLAS (dgemm/zgemm) for matrix operations in spir_sampling_eval_dd/zz, spir_sampling_fit_dd/zz, and spir_dlr2ir_dd/zz functions, improving performance over the default Faer backend.