### PR TITLE
refactor: simplify check_version.py to warn-only for binding versions

### DIFF
--- a/.github/workflows/cxx_tests.yml
+++ b/.github/workflows/cxx_tests.yml
@@ -19,8 +19,6 @@ jobs:
       with:
         submodules: false
         token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Check version consistency
-      run: python3 check_version.py
     - name: Initialize and update submodules
       run: |
         # Convert SSH URLs to HTTPS for GitHub Actions
@@ -42,8 +40,6 @@ jobs:
       with:
         submodules: false
         token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Check version consistency
-      run: python3 check_version.py
     - name: Install OpenBLAS
       run: |
         sudo apt-get update
@@ -69,8 +65,6 @@ jobs:
       with:
         submodules: false
         token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Check version consistency
-      run: python3 check_version.py
     - name: Install OpenBLAS with ILP64
       run: |
         sudo apt-get update

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,9 +24,6 @@ jobs:
           submodules: false
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check version consistency
-        run: python3 check_version.py
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,9 +20,6 @@ jobs:
           submodules: false
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check version consistency
-        run: python3 check_version.py
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -46,9 +43,6 @@ jobs:
         with:
           submodules: false
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check version consistency
-        run: python3 check_version.py
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust_capi.yml
+++ b/.github/workflows/rust_capi.yml
@@ -19,8 +19,6 @@ jobs:
       with:
         submodules: false
         token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Check version consistency
-      run: python3 check_version.py
     - name: Install OpenBLAS
       run: |
         sudo apt-get update

--- a/.github/workflows/test_fortran.yml
+++ b/.github/workflows/test_fortran.yml
@@ -21,9 +21,6 @@ jobs:
           submodules: false
           token: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Check version consistency
-        run: python3 check_version.py
-      
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       
@@ -53,9 +50,6 @@ jobs:
         with:
           submodules: false
           token: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Check version consistency
-        run: python3 check_version.py
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ Some doc tests that depend on external BLAS backends are marked as `ignore` and 
 
 ## Version Consistency Check
 
-Check that versions in `Cargo.toml` and `sparse-ir-capi/Cargo.toml` are consistent:
+Check version consistency across the workspace:
 
 ```bash
 python3 check_version.py
 ```
 
-This script verifies that the workspace version matches the pkg-config version in the C API configuration.
+This script reads the canonical version from `[workspace.package]` in `Cargo.toml` and warns if Julia (`julia/build_tarballs.jl`) or Python (`python/pyproject.toml`) versions don't match. Version mismatches produce warnings but don't fail the check.
 
 ## C API (sparse-ir-capi)
 


### PR DESCRIPTION
- Remove pkg_config version check (no longer needed after Cargo.toml cleanup)
- Check Julia/Python binding versions as warnings instead of errors
- Remove check_version.py step from all CI workflows
- Update README.md documentation