### PR TITLE
fix: fix conda build and add version check workflow

### DIFF
--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -1,0 +1,23 @@
+name: Check Version
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    name: Check version consistency
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check version consistency
+        run: python3 check_version.py

--- a/check_version.py
+++ b/check_version.py
@@ -115,7 +115,20 @@ def main() -> int:
 
     print(f"Workspace version: {workspace_version}")
 
+    errors = []
     warnings = []
+
+    # Check Python version (error if mismatch)
+    python_version = extract_python_version(python_pyproject)
+    if python_version is not None:
+        if python_version != workspace_version:
+            errors.append(
+                f"  Python (python/pyproject.toml): {python_version} != {workspace_version}"
+            )
+        else:
+            print(f"  ✓ Python version matches: {python_version}")
+    else:
+        print(f"  - Python bindings not found (skipped)")
 
     # Check Julia version (warning only)
     julia_version = extract_julia_version(julia_build_tarballs)
@@ -129,28 +142,20 @@ def main() -> int:
     else:
         print(f"  - Julia bindings not found (skipped)")
 
-    # Check Python version (warning only)
-    python_version = extract_python_version(python_pyproject)
-    if python_version is not None:
-        if python_version != workspace_version:
-            warnings.append(
-                f"  Python (python/pyproject.toml): {python_version} != {workspace_version}"
-            )
-        else:
-            print(f"  ✓ Python version matches: {python_version}")
-    else:
-        print(f"  - Python bindings not found (skipped)")
-
     # Print warnings if any
     if warnings:
         print()
-        print("⚠ Version mismatch warnings:")
+        print("⚠ Warnings (update after release):")
         for warning in warnings:
             print(warning)
+
+    # Print errors and fail if any
+    if errors:
         print()
-        print("These bindings may need to be updated before release.")
-        # Return 0 (success) - warnings don't fail the check
-        return 0
+        print("✗ Version mismatch errors:", file=sys.stderr)
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
 
     print()
     print("✓ All version checks passed!")

--- a/python/conda-recipe/meta.yaml
+++ b/python/conda-recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "pylibsparseir" %}
-{% set version = load_file_regex(load_file="../../Cargo.toml", regex_pattern="version = \"([^\"]+)\"", from_recipe_dir=True).group(1) %}
+# Match version in [workspace.package] section
+{% set version = load_file_regex(load_file="../../Cargo.toml", regex_pattern="\\[workspace\\.package\\][^\\[]*version = \"([^\"]+)\"", from_recipe_dir=True).group(1) %}
 
 package:
   name: "{{ name|lower }}"
@@ -44,12 +45,13 @@ requirements:
     - python {{ python }}
     - numpy {{ numpy }}
     - rust
-    - cargo
   host:
     - python {{ python }}
     - numpy {{ numpy }}
     - scipy
     - pytest
+    - pip
+    - hatchling >=1.21.0
   run:
     - python {{ python }}
     - numpy {{ numpy }}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pylibsparseir"
-version = "0.7.2"
+version = "0.7.3"
 description = "Python bindings for the sparse-ir-capi library"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
## Summary
- Fix conda `meta.yaml` regex to correctly match `[workspace.package]` version
- Remove `cargo` from build deps (included in `rust` package)
- Add `hatchling` to host deps for pip install
- Update `pyproject.toml` version to 0.7.3
- Add `check_version.yml` workflow for version consistency checks
- Python version mismatch is now an error, Julia is warning only

## Test plan
- [x] `python3 check_version.py` passes
- [ ] CI workflows pass