### PR TITLE
fix: use Default trait instead of mem::zeroed for statistics markers

### DIFF
--- a/sparse-ir/src/basis.rs
+++ b/sparse-ir/src/basis.rs
@@ -214,9 +214,9 @@ where
         let uhat_base_full = sve_result.u.scale_data(beta.sqrt());
         let conv_rad = kernel.conv_radius();
 
-        // Create statistics instance - we need a value of type S
-        // For Fermionic: S = Fermionic, for Bosonic: S = Bosonic
-        let stat_marker = unsafe { std::mem::zeroed::<S>() };
+        // Create statistics marker instance using Default trait
+        // S is a zero-sized type (ZST) like Fermionic or Bosonic
+        let stat_marker = S::default();
 
         let uhat_full = PiecewiseLegendreFTVector::<S>::from_poly_vector(
             &uhat_base_full,

--- a/sparse-ir/src/traits.rs
+++ b/sparse-ir/src/traits.rs
@@ -8,12 +8,16 @@ pub enum Statistics {
 }
 
 /// Statistics type trait for compile-time type-level distinction
-pub trait StatisticsType: Copy {
+///
+/// # Safety
+/// Types implementing this trait must be zero-sized types (ZST) used only as
+/// compile-time markers. The `Default` bound ensures safe instantiation.
+pub trait StatisticsType: Copy + Default {
     const STATISTICS: Statistics;
 }
 
 /// Fermionic statistics marker type
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct Fermionic;
 
 impl StatisticsType for Fermionic {
@@ -21,7 +25,7 @@ impl StatisticsType for Fermionic {
 }
 
 /// Bosonic statistics marker type
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct Bosonic;
 
 impl StatisticsType for Bosonic {


### PR DESCRIPTION
## Summary
- Replace unsafe `std::mem::zeroed::<S>()` with safe `S::default()` for creating statistics marker instances
- Add `Default` bound to `StatisticsType` trait
- Add `Default` derive to `Fermionic` and `Bosonic` marker types

## Motivation
The previous implementation used `unsafe { std::mem::zeroed::<S>() }` to create instances of statistics marker types. While this worked because these types are Zero-Sized Types (ZST), it was:
1. Unsafe and could cause undefined behavior if a non-ZST type was used
2. Not idiomatic Rust

Using `Default::default()` is the safe and idiomatic way to create marker instances.

## Test plan
- [x] `cargo test --release -p sparse-ir` - All tests pass
- [x] `cargo test --release -p sparse-ir-capi` - All tests pass
- [x] `cxx_tests/run_with_rust_capi.sh` - All tests pass