### PR TITLE
refactor: add exp_m1 method to CustomNumeric trait

### DIFF
--- a/sparse-ir/src/kernel.rs
+++ b/sparse-ir/src/kernel.rs
@@ -16,7 +16,6 @@
 
 use crate::numeric::CustomNumeric;
 use crate::traits::{Statistics, StatisticsType};
-use libm::expm1 as libm_expm1;
 use simba::scalar::ComplexField;
 use std::fmt::Debug;
 
@@ -488,24 +487,6 @@ pub struct RegularizedBoseKernel {
     pub lambda: f64,
 }
 
-/// Helper function to compute expm1(-absv) for different numeric types
-/// Uses exp_m1() for Df64 and libm::expm1 for f64
-fn _exp_m1<T: CustomNumeric>(absv: T) -> T {
-    match std::any::TypeId::of::<T>() {
-        id if id == std::any::TypeId::of::<crate::Df64>() => {
-            // Safe: we know T is Df64, use exp_m1() method from ComplexField trait
-            let df64_absv: crate::Df64 = unsafe { std::mem::transmute_copy(&absv) };
-            let expm1_result = (-df64_absv).exp_m1();
-            unsafe { std::mem::transmute_copy(&expm1_result) }
-        }
-        _ => {
-            // For f64, use libm::expm1 for better numerical stability
-            let f64_absv = absv.to_f64();
-            T::from_f64_unchecked(libm_expm1(-f64_absv))
-        }
-    }
-}
-
 impl RegularizedBoseKernel {
     /// Create a new RegularizedBoseKernel
     ///
@@ -574,7 +555,7 @@ impl RegularizedBoseKernel {
         // Follows SparseIR.jl implementation: denom = absv / expm1(-absv)
         // This is more accurate than exp(-absv) - 1 for small arguments
         let denom = if absv.to_f64() >= 1e-200 {
-            let expm1_neg_absv = _exp_m1(absv);
+            let expm1_neg_absv = CustomNumeric::exp_m1(-absv);
             absv / expm1_neg_absv
         } else {
             // For very small absv, use -1 (matches SparseIR.jl: -one(absv))

--- a/sparse-ir/src/numeric.rs
+++ b/sparse-ir/src/numeric.rs
@@ -4,6 +4,7 @@
 //! for high-precision numerical computation in gauss quadrature and matrix operations.
 
 use crate::Df64;
+use libm::expm1;
 use simba::scalar::ComplexField;
 use std::fmt::Debug;
 
@@ -69,6 +70,12 @@ pub trait CustomNumeric:
     /// Note: Only abs() has this problem - other math functions (exp, cos, sin, sqrt) 
     /// already return Self directly from ComplexField.
     fn abs_as_same_type(self) -> Self;
+
+    /// Compute exp(self) - 1 with higher precision for small values
+    ///
+    /// This is more accurate than `self.exp() - 1` when self is close to zero,
+    /// avoiding catastrophic cancellation.
+    fn exp_m1(self) -> Self;
 }
 
 /// f64 implementation of CustomNumeric
@@ -123,6 +130,10 @@ impl CustomNumeric for f64 {
 
     fn abs_as_same_type(self) -> Self {
         Self::convert_from(self.abs())
+    }
+
+    fn exp_m1(self) -> Self {
+        expm1(self)
     }
 }
 
@@ -193,6 +204,11 @@ impl CustomNumeric for Df64 {
 
     fn abs_as_same_type(self) -> Self {
         Self::convert_from(self.abs())
+    }
+
+    fn exp_m1(self) -> Self {
+        // Use ComplexField::exp_m1() for Df64
+        ComplexField::exp_m1(self)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `exp_m1()` method to `CustomNumeric` trait
- Remove unsafe `_exp_m1()` helper function from `kernel.rs`
- Implement `exp_m1()` for `f64` using `libm::expm1`
- Implement `exp_m1()` for `Df64` using `ComplexField::exp_m1`

## Motivation
The previous `_exp_m1()` helper function used runtime TypeId checks and unsafe `transmute_copy` operations to handle different numeric types. This was:

1. **Unsafe**: Used transmute_copy which can cause undefined behavior
2. **Not idiomatic**: Runtime type dispatch instead of compile-time polymorphism
3. **Not extensible**: Adding new numeric types required modifying the helper

Using a trait method is the standard Rust pattern for this kind of polymorphism.

## Test plan
- [x] `cargo test --release -p sparse-ir` - All tests pass
- [x] `cargo test --release -p sparse-ir-capi` - All tests pass
- [x] `cxx_tests/run_with_rust_capi.sh` - All tests pass