### PR TITLE
refactor: encapsulate FiniteTempBasis fields with getters

### DIFF
--- a/sparse-ir-capi/src/basis.rs
+++ b/sparse-ir-capi/src/basis.rs
@@ -655,14 +655,16 @@ pub unsafe extern "C" fn spir_basis_get_u(
 
         let funcs = match basis_ref.inner() {
             BasisType::LogisticFermionic(basis) => {
-                spir_funcs::from_u_fermionic(basis.u.clone(), beta)
+                spir_funcs::from_u_fermionic(basis.u().clone(), beta)
             }
-            BasisType::LogisticBosonic(basis) => spir_funcs::from_u_bosonic(basis.u.clone(), beta),
+            BasisType::LogisticBosonic(basis) => {
+                spir_funcs::from_u_bosonic(basis.u().clone(), beta)
+            }
             BasisType::RegularizedBoseFermionic(basis) => {
-                spir_funcs::from_u_fermionic(basis.u.clone(), beta)
+                spir_funcs::from_u_fermionic(basis.u().clone(), beta)
             }
             BasisType::RegularizedBoseBosonic(basis) => {
-                spir_funcs::from_u_bosonic(basis.u.clone(), beta)
+                spir_funcs::from_u_bosonic(basis.u().clone(), beta)
             }
             // DLR: tau-domain functions using discrete poles
             // Note: DLR always uses LogisticKernel
@@ -742,10 +744,12 @@ pub unsafe extern "C" fn spir_basis_get_v(
         let beta = basis_ref.beta();
 
         let funcs = match basis_ref.inner() {
-            BasisType::LogisticFermionic(basis) => spir_funcs::from_v(basis.v.clone(), beta),
-            BasisType::LogisticBosonic(basis) => spir_funcs::from_v(basis.v.clone(), beta),
-            BasisType::RegularizedBoseFermionic(basis) => spir_funcs::from_v(basis.v.clone(), beta),
-            BasisType::RegularizedBoseBosonic(basis) => spir_funcs::from_v(basis.v.clone(), beta),
+            BasisType::LogisticFermionic(basis) => spir_funcs::from_v(basis.v().clone(), beta),
+            BasisType::LogisticBosonic(basis) => spir_funcs::from_v(basis.v().clone(), beta),
+            BasisType::RegularizedBoseFermionic(basis) => {
+                spir_funcs::from_v(basis.v().clone(), beta)
+            }
+            BasisType::RegularizedBoseBosonic(basis) => spir_funcs::from_v(basis.v().clone(), beta),
             // DLR: no continuous functions (v)
             BasisType::DLRFermionic(_) | BasisType::DLRBosonic(_) => {
                 return Result::<*mut spir_funcs, String>::Err(
@@ -874,16 +878,16 @@ pub unsafe extern "C" fn spir_basis_get_uhat(
 
         let funcs = match basis_ref.inner() {
             BasisType::LogisticFermionic(basis) => {
-                spir_funcs::from_uhat_fermionic(basis.uhat.clone(), beta)
+                spir_funcs::from_uhat_fermionic(basis.uhat().clone(), beta)
             }
             BasisType::LogisticBosonic(basis) => {
-                spir_funcs::from_uhat_bosonic(basis.uhat.clone(), beta)
+                spir_funcs::from_uhat_bosonic(basis.uhat().clone(), beta)
             }
             BasisType::RegularizedBoseFermionic(basis) => {
-                spir_funcs::from_uhat_fermionic(basis.uhat.clone(), beta)
+                spir_funcs::from_uhat_fermionic(basis.uhat().clone(), beta)
             }
             BasisType::RegularizedBoseBosonic(basis) => {
-                spir_funcs::from_uhat_bosonic(basis.uhat.clone(), beta)
+                spir_funcs::from_uhat_bosonic(basis.uhat().clone(), beta)
             }
             // DLR: Matsubara-domain functions using discrete poles
             BasisType::DLRFermionic(dlr) => spir_funcs::from_dlr_matsubara_fermionic(
@@ -975,16 +979,16 @@ pub unsafe extern "C" fn spir_basis_get_uhat_full(
 
         let funcs = match basis_ref.inner() {
             BasisType::LogisticFermionic(basis) => {
-                spir_funcs::from_uhat_full_fermionic(basis.uhat_full.clone(), beta)
+                spir_funcs::from_uhat_full_fermionic(basis.uhat_full().clone(), beta)
             }
             BasisType::LogisticBosonic(basis) => {
-                spir_funcs::from_uhat_full_bosonic(basis.uhat_full.clone(), beta)
+                spir_funcs::from_uhat_full_bosonic(basis.uhat_full().clone(), beta)
             }
             BasisType::RegularizedBoseFermionic(basis) => {
-                spir_funcs::from_uhat_full_fermionic(basis.uhat_full.clone(), beta)
+                spir_funcs::from_uhat_full_fermionic(basis.uhat_full().clone(), beta)
             }
             BasisType::RegularizedBoseBosonic(basis) => {
-                spir_funcs::from_uhat_full_bosonic(basis.uhat_full.clone(), beta)
+                spir_funcs::from_uhat_full_bosonic(basis.uhat_full().clone(), beta)
             }
             // DLR: not supported (only IR basis has uhat_full)
             BasisType::DLRFermionic(_) | BasisType::DLRBosonic(_) => {

--- a/sparse-ir-capi/src/types.rs
+++ b/sparse-ir-capi/src/types.rs
@@ -327,10 +327,10 @@ impl spir_basis {
 
     pub(crate) fn svals(&self) -> Vec<f64> {
         match self.inner_type() {
-            BasisType::LogisticFermionic(b) => b.s.clone(),
-            BasisType::LogisticBosonic(b) => b.s.clone(),
-            BasisType::RegularizedBoseFermionic(b) => b.s.clone(),
-            BasisType::RegularizedBoseBosonic(b) => b.s.clone(),
+            BasisType::LogisticFermionic(b) => b.s().to_vec(),
+            BasisType::LogisticBosonic(b) => b.s().to_vec(),
+            BasisType::RegularizedBoseFermionic(b) => b.s().to_vec(),
+            BasisType::RegularizedBoseBosonic(b) => b.s().to_vec(),
             // DLR: no singular values, return empty
             BasisType::DLRFermionic(_) | BasisType::DLRBosonic(_) => vec![],
         }
@@ -350,10 +350,10 @@ impl spir_basis {
 
     pub(crate) fn beta(&self) -> f64 {
         match self.inner_type() {
-            BasisType::LogisticFermionic(b) => b.beta,
-            BasisType::LogisticBosonic(b) => b.beta,
-            BasisType::RegularizedBoseFermionic(b) => b.beta,
-            BasisType::RegularizedBoseBosonic(b) => b.beta,
+            BasisType::LogisticFermionic(b) => b.beta(),
+            BasisType::LogisticBosonic(b) => b.beta(),
+            BasisType::RegularizedBoseFermionic(b) => b.beta(),
+            BasisType::RegularizedBoseBosonic(b) => b.beta(),
             BasisType::DLRFermionic(dlr) => dlr.beta,
             BasisType::DLRBosonic(dlr) => dlr.beta,
         }

--- a/sparse-ir/src/basis.rs
+++ b/sparse-ir/src/basis.rs
@@ -42,35 +42,35 @@ where
     S: StatisticsType,
 {
     /// The kernel used to construct this basis
-    pub kernel: K,
+    kernel: K,
 
     /// The SVE result (in scaled variables)
-    pub sve_result: Arc<SVEResult>,
+    sve_result: Arc<SVEResult>,
 
     /// Accuracy of the basis (relative error)
-    pub accuracy: f64,
+    accuracy: f64,
 
     /// Inverse temperature β
-    pub beta: f64,
+    beta: f64,
 
     /// Left singular functions on imaginary time axis τ ∈ [0, β]
     /// Arc for efficient sharing (large immutable data)
-    pub u: Arc<PiecewiseLegendrePolyVector>,
+    u: Arc<PiecewiseLegendrePolyVector>,
 
     /// Right singular functions on real frequency axis ω ∈ [-ωmax, ωmax]
     /// Arc for efficient sharing (large immutable data)
-    pub v: Arc<PiecewiseLegendrePolyVector>,
+    v: Arc<PiecewiseLegendrePolyVector>,
 
     /// Singular values
-    pub s: Vec<f64>,
+    s: Vec<f64>,
 
     /// Left singular functions on Matsubara frequency axis (Fourier transform of u)
     /// Arc for efficient sharing (large immutable data)
-    pub uhat: Arc<PiecewiseLegendreFTVector<S>>,
+    uhat: Arc<PiecewiseLegendreFTVector<S>>,
 
     /// Full uhat (before truncation to basis size)
     /// Arc for efficient sharing (large immutable data, used for Matsubara sampling)
-    pub uhat_full: Arc<PiecewiseLegendreFTVector<S>>,
+    uhat_full: Arc<PiecewiseLegendreFTVector<S>>,
 
     _phantom: std::marker::PhantomData<S>,
 }
@@ -80,6 +80,55 @@ where
     K: KernelProperties + CentrosymmKernel + Clone + 'static,
     S: StatisticsType,
 {
+    // ========== Getters ==========
+
+    /// Get a reference to the kernel
+    pub fn kernel(&self) -> &K {
+        &self.kernel
+    }
+
+    /// Get the SVE result
+    pub fn sve_result(&self) -> &Arc<SVEResult> {
+        &self.sve_result
+    }
+
+    /// Get the accuracy of the basis
+    pub fn accuracy(&self) -> f64 {
+        self.accuracy
+    }
+
+    /// Get the inverse temperature β
+    pub fn beta(&self) -> f64 {
+        self.beta
+    }
+
+    /// Get the left singular functions (u) on imaginary time axis
+    pub fn u(&self) -> &Arc<PiecewiseLegendrePolyVector> {
+        &self.u
+    }
+
+    /// Get the right singular functions (v) on real frequency axis
+    pub fn v(&self) -> &Arc<PiecewiseLegendrePolyVector> {
+        &self.v
+    }
+
+    /// Get the singular values
+    pub fn s(&self) -> &[f64] {
+        &self.s
+    }
+
+    /// Get the left singular functions on Matsubara frequency axis (uhat)
+    pub fn uhat(&self) -> &Arc<PiecewiseLegendreFTVector<S>> {
+        &self.uhat
+    }
+
+    /// Get the full uhat (before truncation)
+    pub fn uhat_full(&self) -> &Arc<PiecewiseLegendreFTVector<S>> {
+        &self.uhat_full
+    }
+
+    // ========== Other methods ==========
+
     /// Get the frequency cutoff ωmax
     pub fn wmax(&self) -> f64 {
         self.kernel.lambda() / self.beta

--- a/sparse-ir/src/test_utils.rs
+++ b/sparse-ir/src/test_utils.rs
@@ -142,15 +142,15 @@ where
 
     let mut rng = SimpleRng::new(seed);
     let basis_size = basis.size();
-    let beta = basis.beta;
-    let wmax = basis.kernel.lambda() / beta;
+    let beta = basis.beta();
+    let wmax = basis.kernel().lambda() / beta;
 
     // Choose a pole position (arbitrary choice within reasonable range)
     let omega = wmax * 0.5; // Pole at half of wmax
 
     // Generate random coefficients scaled by singular values
     let coeffs: Vec<T> = (0..basis_size)
-        .map(|l| rng.next::<T>() * basis.s[l])
+        .map(|l| rng.next::<T>() * basis.s()[l])
         .collect();
 
     // Compute G(τ) at τ sampling points
@@ -218,8 +218,8 @@ where
     use crate::{giwn_single_pole, gtau_single_pole};
 
     let mut rng = SimpleRng::new(seed);
-    let beta = basis.beta;
-    let wmax = basis.kernel.lambda() / beta;
+    let beta = basis.beta();
+    let wmax = basis.kernel().lambda() / beta;
     let basis_size = basis.size();
 
     // Calculate total number of extra elements
@@ -254,7 +254,7 @@ where
         for l in 0..basis_size {
             let random_base: T = rng.next();
             let random_centered = random_base * T::from(2.0) - T::from(1.0);
-            let scaled_coeff = random_centered * basis.s[l];
+            let scaled_coeff = random_centered * basis.s()[l];
 
             let mut full_idx = vec![l];
             full_idx.extend_from_slice(&extra_idx);

--- a/sparse-ir/tests/basis_comparison.rs
+++ b/sparse-ir/tests/basis_comparison.rs
@@ -392,7 +392,7 @@ fn test_basis_singular_values_lambda_10_beta_1() {
 
     let tol = 1e-10;
     for i in 0..ref_data.svals.len() {
-        let s_rust = basis_f.s[i];
+        let s_rust = basis_f.s()[i];
         let s_julia = ref_data.svals[i];
         let diff = (s_rust - s_julia).abs();
         println!(
@@ -424,7 +424,7 @@ fn test_basis_u_tau_lambda_10_beta_1() {
     for (tau_idx, &tau) in ref_data.tau_points.iter().enumerate() {
         println!("\n  tau = {}", tau);
         for l in 0..3.min(basis_f.size()) {
-            let u_rust = basis_f.u[l].evaluate(tau);
+            let u_rust = basis_f.u()[l].evaluate(tau);
             let u_julia = ref_data.u_tau_f[tau_idx][l];
             let diff = (u_rust - u_julia).abs();
             println!(
@@ -458,7 +458,7 @@ fn test_basis_v_omega_lambda_10_beta_1() {
     for (omega_idx, &omega) in ref_data.omega_points.iter().enumerate() {
         println!("\n  omega = {}", omega);
         for l in 0..3.min(basis_f.size()) {
-            let v_rust = basis_f.v[l].evaluate(omega);
+            let v_rust = basis_f.v()[l].evaluate(omega);
             let v_julia = ref_data.v_omega_f[omega_idx][l];
             let diff = (v_rust - v_julia).abs();
             println!(
@@ -492,7 +492,7 @@ fn test_basis_uhat_wn_fermionic_lambda_10_beta_1() {
     for (wn_idx, &wn) in ref_data.wn_f.iter().enumerate() {
         println!("\n  wn = {} (n={})", wn, (wn - 1) / 2);
         for l in 0..3.min(basis_f.size()) {
-            let uhat_rust = basis_f.uhat.polyvec[l].evaluate_at_n(wn);
+            let uhat_rust = basis_f.uhat().polyvec[l].evaluate_at_n(wn);
             let uhat_julia = ref_data.uhat_wn_f[wn_idx][l];
             let diff = (uhat_rust - uhat_julia).norm();
             println!(
@@ -528,7 +528,7 @@ fn test_basis_uhat_wn_bosonic_lambda_10_beta_1() {
     for (wn_idx, &wn) in ref_data.wn_b.iter().enumerate() {
         println!("\n  wn = {} (n={})", wn, wn / 2);
         for l in 0..3.min(basis_b.size()) {
-            let uhat_rust = basis_b.uhat.polyvec[l].evaluate_at_n(wn);
+            let uhat_rust = basis_b.uhat().polyvec[l].evaluate_at_n(wn);
             let uhat_julia = ref_data.uhat_wn_b[wn_idx][l];
             let diff = (uhat_rust - uhat_julia).norm();
             println!(
@@ -598,7 +598,7 @@ fn test_basis_uhat_wn_lambda_1000_beta_100() {
     let tol = 1e-10;
 
     // Fermionic - check first basis function at wn=1
-    let uhat_rust = basis_f.uhat.polyvec[0].evaluate_at_n(ref_data.wn_f[0]);
+    let uhat_rust = basis_f.uhat().polyvec[0].evaluate_at_n(ref_data.wn_f[0]);
     let uhat_julia = ref_data.uhat_wn_f[0][0];
     let diff = (uhat_rust - uhat_julia).norm();
     assert!(
@@ -609,7 +609,7 @@ fn test_basis_uhat_wn_lambda_1000_beta_100() {
     );
 
     // Bosonic - check first basis function at wn=0
-    let uhat_rust = basis_b.uhat.polyvec[0].evaluate_at_n(ref_data.wn_b[0]);
+    let uhat_rust = basis_b.uhat().polyvec[0].evaluate_at_n(ref_data.wn_b[0]);
     let uhat_julia = ref_data.uhat_wn_b[0][0];
     let diff = (uhat_rust - uhat_julia).norm();
     assert!(


### PR DESCRIPTION
## Summary
- Make all public fields of `FiniteTempBasis` private
- Add getter methods for all fields
- Update all usage sites in `sparse-ir` and `sparse-ir-capi`

## Breaking Change ⚠️
This is a **breaking change** for external code that directly accessed the fields of `FiniteTempBasis`. The following field accesses need to be updated:

| Before | After |
|--------|-------|
| `basis.kernel` | `basis.kernel()` |
| `basis.sve_result` | `basis.sve_result()` |
| `basis.accuracy` | `basis.accuracy()` |
| `basis.beta` | `basis.beta()` |
| `basis.u` | `basis.u()` |
| `basis.v` | `basis.v()` |
| `basis.s` | `basis.s()` |
| `basis.uhat` | `basis.uhat()` |
| `basis.uhat_full` | `basis.uhat_full()` |

## Motivation
Public fields break encapsulation and make future changes to internal representation breaking. Using getter methods:

1. **Encapsulation**: Internal representation can change without breaking API
2. **Consistency**: Follows Rust best practices for public structs
3. **Safety**: Prevents accidental mutation of internal state

## Test plan
- [x] `cargo test --release -p sparse-ir` - All tests pass
- [x] `cargo test --release -p sparse-ir-capi` - All tests pass
- [x] `cxx_tests/run_with_rust_capi.sh` - All tests pass