### PR TITLE
fix: resolve rustdoc warnings in sparse-ir-capi

### DIFF
--- a/sparse-ir-capi/include/sparseir/sparseir.h
+++ b/sparse-ir-capi/include/sparseir/sparseir.h
@@ -57,7 +57,7 @@ typedef struct spir_kernel {
  * Contains singular values and singular functions from SVE computation.
  *
  * Note: Named `spir_sve_result` to match libsparseir C++ API exactly.
- * The internal structure is hidden using a void pointer to prevent exposing Arc<SVEResult> to C.
+ * The internal structure is hidden using a void pointer to prevent exposing `Arc<SVEResult>` to C.
  */
 typedef struct spir_sve_result {
   const void *_private;
@@ -860,7 +860,7 @@ struct spir_funcs *spir_funcs_get_slice(const struct spir_funcs *funcs,
  * # Safety
  * - `xs` must have size >= `num_points`
  * - `out` must have size >= `num_points * spir_funcs_get_size(funcs)`
- * - Layout: row-major = out[point][func], column-major = out[func][point]
+ * - Layout: row-major = out\[point\]\[func\], column-major = out\[func\]\[point\]
  */
 
 StatusCode spir_funcs_batch_eval(const struct spir_funcs *funcs,
@@ -886,7 +886,7 @@ StatusCode spir_funcs_batch_eval(const struct spir_funcs *funcs,
  * - `ns` must have size >= `num_freqs`
  * - `out` must have size >= `num_freqs * spir_funcs_get_size(funcs)`
  * - Complex numbers are laid out as [real, imag] pairs
- * - Layout: row-major = out[freq][func], column-major = out[func][freq]
+ * - Layout: row-major = out\[freq\]\[func\], column-major = out\[func\]\[freq\]
  */
 
 StatusCode spir_funcs_batch_eval_matsu(const struct spir_funcs *funcs,
@@ -1649,12 +1649,12 @@ struct spir_sve_result *spir_sve_result_new(const struct spir_kernel *k,
  * Truncate an SVE result based on epsilon and max_size
  *
  * This function creates a new SVE result containing only the singular values
- * that are larger than `epsilon * s[0]`, where `s[0]` is the largest singular value.
+ * that are larger than `epsilon * s\[0\]`, where `s\[0\]` is the largest singular value.
  * The result can also be limited to a maximum size.
  *
  * # Arguments
  * * `sve` - Source SVE result object
- * * `epsilon` - Relative threshold for truncation (singular values < epsilon * s[0] are removed)
+ * * `epsilon` - Relative threshold for truncation (singular values < epsilon * s\[0\] are removed)
  * * `max_size` - Maximum number of singular values to keep (-1 for no limit)
  * * `status` - Pointer to store status code
  *

--- a/sparse-ir-capi/src/funcs.rs
+++ b/sparse-ir-capi/src/funcs.rs
@@ -473,7 +473,7 @@ pub extern "C" fn spir_funcs_eval_matsu(
 /// # Safety
 /// - `xs` must have size >= `num_points`
 /// - `out` must have size >= `num_points * spir_funcs_get_size(funcs)`
-/// - Layout: row-major = out[point][func], column-major = out[func][point]
+/// - Layout: row-major = out\[point\]\[func\], column-major = out\[func\]\[point\]
 #[unsafe(no_mangle)]
 pub extern "C" fn spir_funcs_batch_eval(
     funcs: *const spir_funcs,
@@ -541,7 +541,7 @@ pub extern "C" fn spir_funcs_batch_eval(
 /// - `ns` must have size >= `num_freqs`
 /// - `out` must have size >= `num_freqs * spir_funcs_get_size(funcs)`
 /// - Complex numbers are laid out as [real, imag] pairs
-/// - Layout: row-major = out[freq][func], column-major = out[func][freq]
+/// - Layout: row-major = out\[freq\]\[func\], column-major = out\[func\]\[freq\]
 #[unsafe(no_mangle)]
 pub extern "C" fn spir_funcs_batch_eval_matsu(
     funcs: *const spir_funcs,

--- a/sparse-ir-capi/src/sve.rs
+++ b/sparse-ir-capi/src/sve.rs
@@ -217,12 +217,12 @@ pub extern "C" fn spir_sve_result_get_size(
 /// Truncate an SVE result based on epsilon and max_size
 ///
 /// This function creates a new SVE result containing only the singular values
-/// that are larger than `epsilon * s[0]`, where `s[0]` is the largest singular value.
+/// that are larger than `epsilon * s\[0\]`, where `s\[0\]` is the largest singular value.
 /// The result can also be limited to a maximum size.
 ///
 /// # Arguments
 /// * `sve` - Source SVE result object
-/// * `epsilon` - Relative threshold for truncation (singular values < epsilon * s[0] are removed)
+/// * `epsilon` - Relative threshold for truncation (singular values < epsilon * s\[0\] are removed)
 /// * `max_size` - Maximum number of singular values to keep (-1 for no limit)
 /// * `status` - Pointer to store status code
 ///

--- a/sparse-ir-capi/src/types.rs
+++ b/sparse-ir-capi/src/types.rs
@@ -79,7 +79,7 @@ pub struct spir_kernel {
 /// Contains singular values and singular functions from SVE computation.
 ///
 /// Note: Named `spir_sve_result` to match libsparseir C++ API exactly.
-/// The internal structure is hidden using a void pointer to prevent exposing Arc<SVEResult> to C.
+/// The internal structure is hidden using a void pointer to prevent exposing `Arc<SVEResult>` to C.
 #[repr(C)]
 pub struct spir_sve_result {
     pub(crate) _private: *const std::ffi::c_void,

--- a/sparse-ir-capi/src/utils.rs
+++ b/sparse-ir-capi/src/utils.rs
@@ -53,7 +53,7 @@ impl MemoryOrder {
 /// (mdarray_dims, mdarray_target_dim) - Dimensions and target_dim for row-major mdarray
 ///
 /// # Example
-/// ```ignore
+/// ```text
 /// // Julia: dims=[5, 3], target_dim=0, order=COLUMN_MAJOR
 /// convert_dims_for_row_major(&[5, 3], 0, MemoryOrder::ColumnMajor)
 /// → ([3, 5], 1)  // For row-major mdarray


### PR DESCRIPTION
## Summary
- Fix rustdoc warnings in sparse-ir-capi docs (escape `[]` in layout examples, wrap `Arc<SVEResult>` in backticks, and mark non-Rust example blocks as text).

## Test plan
- [x] `cargo doc -p sparse-ir-capi --no-deps`
- [x] `DOCS_RS=1 cargo +nightly rustdoc -p sparse-ir-capi --lib`
- [x] `cargo test -p sparse-ir-capi`
- [x] `cargo test -p sparse-ir`