### PR TITLE
fix: make system BLAS tests conditional on system-blas feature

### DIFF
--- a/sparse-ir-capi/src/gemm.rs
+++ b/sparse-ir-capi/src/gemm.rs
@@ -345,8 +345,8 @@ mod tests {
         }
     }
 
-    // System BLAS integration tests (always enabled during tests)
-    #[cfg(test)]
+    // System BLAS integration tests (only when system-blas feature is enabled)
+    #[cfg(all(test, feature = "system-blas"))]
     mod system_blas_tests {
         use super::*;
         use blas_sys::{dgemm_, zgemm_};


### PR DESCRIPTION
## Summary
- Fixed linking errors when running `cargo test` on systems without BLAS installed
- Made `system_blas_tests` module conditional on the `system-blas` feature flag

## Problem
The `system_blas_tests` module in `sparse-ir-capi/src/gemm.rs` was unconditionally importing and using `blas_sys::{dgemm_, zgemm_}`, which caused linker failures on Windows and other systems without BLAS libraries installed:

```
error LNK2019: unresolved external symbol dgemm_
error LNK2019: unresolved external symbol zgemm_
```

## Solution
Changed the module's conditional compilation attribute from:
```rust
#[cfg(test)]
mod system_blas_tests {
```

To:
```rust
#[cfg(all(test, feature = "system-blas"))]
mod system_blas_tests {
```

This ensures the BLAS integration tests only compile when the `system-blas` feature is explicitly enabled, while other tests continue to work on all platforms.

## Test plan
- [x] Verify `cargo test` passes on systems without BLAS (Windows, etc.)
- [ ] Verify `cargo test --features system-blas` still runs BLAS integration tests when BLAS is available
- [x] Confirm all other tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)