### PR TITLE
fix: make Matsubara fit cache thread-safe

### DIFF
--- a/sparse-ir-capi/tests/integration_test.rs
+++ b/sparse-ir-capi/tests/integration_test.rs
@@ -16,6 +16,8 @@ use sparse_ir_capi::{
     spir_sampling_fit_dd, spir_sampling_fit_zd, spir_sampling_fit_zz, spir_sampling_release,
     spir_sve_result, spir_sve_result_new, spir_sve_result_release, spir_tau_sampling_new,
 };
+use std::sync::{Arc, Barrier};
+use std::thread;
 
 // ============================================================================
 // Helper Functions
@@ -704,6 +706,172 @@ fn test_complex_coefficients(#[case] epsilon: f64) {
         assert!(max_error < 1e-10);
 
         // Cleanup
+        spir_sampling_release(matsu_sampling);
+        spir_basis_release(basis);
+        spir_sve_result_release(sve);
+        spir_kernel_release(kernel);
+    }
+}
+
+#[test]
+fn test_concurrent_matsubara_fit_zz_is_thread_safe() {
+    let beta = 0.7;
+    let wmax = 8.0;
+    let epsilon = 1e-2;
+
+    unsafe {
+        let (kernel, sve, basis) = create_ir_basis(1, beta, wmax, epsilon);
+        let basis_size = get_basis_size(basis) as usize;
+        let matsu_points = get_default_matsubara_points(basis, false);
+        let num_matsu = matsu_points.len();
+
+        let mut status = SPIR_INTERNAL_ERROR;
+        let matsu_sampling = spir_matsu_sampling_new(
+            basis,
+            false,
+            num_matsu as i32,
+            matsu_points.as_ptr(),
+            &mut status,
+        );
+        assert_eq!(status, SPIR_COMPUTATION_SUCCESS);
+        assert!(!matsu_sampling.is_null());
+
+        let coeffs: Vec<Complex64> = (0..basis_size)
+            .map(|i| Complex64::new((i as f64 + 1.0) * 0.1, (i as f64 + 1.0) * 0.05))
+            .collect();
+
+        let mut giw = vec![Complex64::new(0.0, 0.0); num_matsu];
+        let dims = [basis_size as i32];
+        let status = spir_sampling_eval_zz(
+            matsu_sampling,
+            std::ptr::null(),
+            SPIR_ORDER_ROW_MAJOR,
+            1,
+            dims.as_ptr(),
+            0,
+            coeffs.as_ptr(),
+            giw.as_mut_ptr(),
+        );
+        assert_eq!(status, SPIR_COMPUTATION_SUCCESS);
+
+        let barrier = Arc::new(Barrier::new(8));
+        let sampling_addr = matsu_sampling as usize;
+        let giw = Arc::new(giw);
+
+        thread::scope(|scope| {
+            let mut handles = Vec::new();
+            for _ in 0..8 {
+                let barrier = Arc::clone(&barrier);
+                let giw = Arc::clone(&giw);
+                handles.push(scope.spawn(move || {
+                    barrier.wait();
+                    for _ in 0..20 {
+                        let mut coeffs_fit = vec![Complex64::new(0.0, 0.0); basis_size];
+                        let dims_matsu = [num_matsu as i32];
+                        let status = unsafe {
+                            spir_sampling_fit_zz(
+                                sampling_addr as *const _,
+                                std::ptr::null(),
+                                SPIR_ORDER_ROW_MAJOR,
+                                1,
+                                dims_matsu.as_ptr(),
+                                0,
+                                giw.as_ptr(),
+                                coeffs_fit.as_mut_ptr(),
+                            )
+                        };
+                        assert_eq!(status, SPIR_COMPUTATION_SUCCESS);
+                    }
+                }));
+            }
+
+            for handle in handles {
+                handle.join().unwrap();
+            }
+        });
+
+        spir_sampling_release(matsu_sampling);
+        spir_basis_release(basis);
+        spir_sve_result_release(sve);
+        spir_kernel_release(kernel);
+    }
+}
+
+#[test]
+fn test_concurrent_matsubara_fit_zd_positive_only_is_thread_safe() {
+    let beta = 0.7;
+    let wmax = 8.0;
+    let epsilon = 1e-2;
+
+    unsafe {
+        let (kernel, sve, basis) = create_ir_basis(1, beta, wmax, epsilon);
+        let basis_size = get_basis_size(basis) as usize;
+        let matsu_points = get_default_matsubara_points(basis, true);
+        let num_matsu = matsu_points.len();
+
+        let mut status = SPIR_INTERNAL_ERROR;
+        let matsu_sampling = spir_matsu_sampling_new(
+            basis,
+            true,
+            num_matsu as i32,
+            matsu_points.as_ptr(),
+            &mut status,
+        );
+        assert_eq!(status, SPIR_COMPUTATION_SUCCESS);
+        assert!(!matsu_sampling.is_null());
+
+        let coeffs: Vec<f64> = (0..basis_size).map(|i| (i as f64 + 1.0) * 0.25).collect();
+
+        let mut giw = vec![Complex64::new(0.0, 0.0); num_matsu];
+        let dims = [basis_size as i32];
+        let status = spir_sampling_eval_dz(
+            matsu_sampling,
+            std::ptr::null(),
+            SPIR_ORDER_ROW_MAJOR,
+            1,
+            dims.as_ptr(),
+            0,
+            coeffs.as_ptr(),
+            giw.as_mut_ptr(),
+        );
+        assert_eq!(status, SPIR_COMPUTATION_SUCCESS);
+
+        let barrier = Arc::new(Barrier::new(8));
+        let sampling_addr = matsu_sampling as usize;
+        let giw = Arc::new(giw);
+
+        thread::scope(|scope| {
+            let mut handles = Vec::new();
+            for _ in 0..8 {
+                let barrier = Arc::clone(&barrier);
+                let giw = Arc::clone(&giw);
+                handles.push(scope.spawn(move || {
+                    barrier.wait();
+                    for _ in 0..20 {
+                        let mut coeffs_fit = vec![0.0; basis_size];
+                        let dims_matsu = [num_matsu as i32];
+                        let status = unsafe {
+                            spir_sampling_fit_zd(
+                                sampling_addr as *const _,
+                                std::ptr::null(),
+                                SPIR_ORDER_ROW_MAJOR,
+                                1,
+                                dims_matsu.as_ptr(),
+                                0,
+                                giw.as_ptr(),
+                                coeffs_fit.as_mut_ptr(),
+                            )
+                        };
+                        assert_eq!(status, SPIR_COMPUTATION_SUCCESS);
+                    }
+                }));
+            }
+
+            for handle in handles {
+                handle.join().unwrap();
+            }
+        });
+
         spir_sampling_release(matsu_sampling);
         spir_basis_release(basis);
         spir_sve_result_release(sve);

--- a/sparse-ir/src/fitters/complex.rs
+++ b/sparse-ir/src/fitters/complex.rs
@@ -6,7 +6,7 @@
 use crate::gemm::GemmBackendHandle;
 use mdarray::{DTensor, DView, DynRank, Shape, Slice, ViewMut};
 use num_complex::Complex;
-use std::cell::RefCell;
+use std::sync::OnceLock;
 
 use super::common::{
     ComplexSVD, InplaceFitter, combine_complex, compute_complex_svd, copy_from_contiguous,
@@ -35,7 +35,7 @@ pub(crate) struct ComplexMatrixFitter {
     matrix_im: DTensor<f64, 2>,   // (n_points, basis_size)
     matrix_re_t: DTensor<f64, 2>, // (basis_size, n_points) - transposed
     matrix_im_t: DTensor<f64, 2>, // (basis_size, n_points) - transposed
-    svd: RefCell<Option<ComplexSVDExtended>>,
+    svd: OnceLock<ComplexSVDExtended>,
 }
 
 /// Extended SVD structure with pre-computed transposes for dim=1 operations
@@ -92,7 +92,7 @@ impl ComplexMatrixFitter {
             matrix_im,
             matrix_re_t,
             matrix_im_t,
-            svd: RefCell::new(None),
+            svd: OnceLock::new(),
         }
     }
 
@@ -383,10 +383,7 @@ impl ComplexMatrixFitter {
         );
 
         // Compute SVD lazily
-        self.ensure_svd();
-
-        let svd_ext = self.svd.borrow();
-        let svd_ext = svd_ext.as_ref().unwrap();
+        let svd_ext = self.get_svd();
         let svd = &svd_ext.svd;
 
         // coeffs_2d = V * S^{-1} * U^H * values_2d
@@ -527,10 +524,7 @@ impl ComplexMatrixFitter {
         let (out_rows, out_cols) = *out.shape();
 
         // Compute SVD lazily
-        self.ensure_svd();
-
-        let svd_ext = self.svd.borrow();
-        let svd_ext = svd_ext.as_ref().unwrap();
+        let svd_ext = self.get_svd();
         let svd = &svd_ext.svd;
         let min_dim = svd.s.len();
 
@@ -617,9 +611,9 @@ impl ComplexMatrixFitter {
         }
     }
 
-    /// Ensure SVD is computed (lazy initialization)
-    fn ensure_svd(&self) {
-        if self.svd.borrow().is_none() {
+    /// Get extended SVD, computing it lazily if needed.
+    fn get_svd(&self) -> &ComplexSVDExtended {
+        self.svd.get_or_init(|| {
             let n_points = self.n_points();
             let basis_size = self.basis_size();
             if n_points < basis_size {
@@ -630,9 +624,8 @@ impl ComplexMatrixFitter {
                 );
             }
             let svd = compute_complex_svd(&self.matrix);
-            let svd_ext = ComplexSVDExtended::from_svd(svd, self.n_points(), self.basis_size());
-            *self.svd.borrow_mut() = Some(svd_ext);
-        }
+            ComplexSVDExtended::from_svd(svd, self.n_points(), self.basis_size())
+        })
     }
 
     /// Evaluate ND complex tensor (along specified dim)

--- a/sparse-ir/src/fitters/complex_to_real.rs
+++ b/sparse-ir/src/fitters/complex_to_real.rs
@@ -10,7 +10,7 @@
 use crate::gemm::GemmBackendHandle;
 use mdarray::{DTensor, DView, DynRank, Shape, Slice, ViewMut};
 use num_complex::Complex;
-use std::cell::RefCell;
+use std::sync::OnceLock;
 
 use super::common::{InplaceFitter, RealSVD, compute_real_svd};
 
@@ -114,7 +114,7 @@ pub(crate) struct ComplexToRealFitter {
     matrix_re_t: DTensor<f64, 2>,         // (basis_size, n_points)
     matrix_im_t: DTensor<f64, 2>,         // (basis_size, n_points)
     pub matrix: DTensor<Complex<f64>, 2>, // (n_points, basis_size) - original complex matrix
-    svd: RefCell<Option<RealSVDExtended>>,
+    svd: OnceLock<RealSVDExtended>,
     n_points: usize, // Original complex point count
 }
 
@@ -184,7 +184,7 @@ impl ComplexToRealFitter {
             matrix_re_t,
             matrix_im_t,
             matrix: matrix_complex.clone(),
-            svd: RefCell::new(None),
+            svd: OnceLock::new(),
             n_points,
         }
     }
@@ -554,14 +554,11 @@ impl ComplexToRealFitter {
         );
 
         // Compute SVD lazily
-        self.ensure_svd();
-
         // Flatten complex values to real: [n_points, extra_size] → [2*n_points, extra_size]
         let mut values_flat = DTensor::<f64, 2>::zeros([2 * n_points, extra_size]);
         flatten_complex_to_real_rows(values_2d, &mut values_flat);
 
-        let svd_ext = self.svd.borrow();
-        let svd_ext = svd_ext.as_ref().unwrap();
+        let svd_ext = self.get_svd();
         let svd = &svd_ext.svd;
 
         // coeffs = V * S^{-1} * U^T * values_flat
@@ -585,9 +582,9 @@ impl ComplexToRealFitter {
         matmul_par_to_viewmut(&v_view, &ut_values_view, out, backend);
     }
 
-    /// Ensure SVD is computed (lazy initialization)
-    fn ensure_svd(&self) {
-        if self.svd.borrow().is_none() {
+    /// Get extended SVD, computing it lazily if needed.
+    fn get_svd(&self) -> &RealSVDExtended {
+        self.svd.get_or_init(|| {
             let n_points = self.n_points();
             let basis_size = self.basis_size();
             // For positive-only mode, we have symmetry: 2*n_points effective points
@@ -599,9 +596,8 @@ impl ComplexToRealFitter {
                     n_points, effective_points, basis_size
                 );
             }
-            let svd_ext = RealSVDExtended::from_matrix(&self.matrix_real);
-            *self.svd.borrow_mut() = Some(svd_ext);
-        }
+            RealSVDExtended::from_matrix(&self.matrix_real)
+        })
     }
 
     /// Fit 2D complex tensor to real coefficients with configurable target dimension
@@ -623,10 +619,7 @@ impl ComplexToRealFitter {
         let (out_rows, out_cols) = *out.shape();
 
         // Compute SVD lazily
-        self.ensure_svd();
-
-        let svd_ext = self.svd.borrow();
-        let svd_ext = svd_ext.as_ref().unwrap();
+        let svd_ext = self.get_svd();
         let svd = &svd_ext.svd;
         let min_dim = svd.s.len();
         let n_points = self.n_points();


### PR DESCRIPTION
## Summary
- replace lazy SVD caches in the complex Matsubara fitters with `OnceLock`
- add concurrent C API regression tests for full-range and positive-only Matsubara fit paths
- keep existing fit/evaluate behavior unchanged while allowing shared sampling objects across threads

## Test Plan
- cargo test -p sparse-ir-capi test_concurrent_matsubara_fit -- --nocapture
- cargo test -p sparse-ir --lib test_nd_roundtrip -- --nocapture
- cargo test -p sparse-ir --lib test_dz_zd_roundtrip -- --nocapture