### PR TITLE
fix(capi): auto-detect release/debug library path in Julia example

### DIFF
--- a/sparse-ir-capi/examples/test_julia.jl
+++ b/sparse-ir-capi/examples/test_julia.jl
@@ -7,7 +7,9 @@ This demonstrates how to call the SparseIR Rust library from Julia.
 
 using Libdl: dlext
 # Load the shared library
-const libpath = "../../target/debug/libsparse_ir_capi.$(dlext)"  # macOS
+const libpath_release = joinpath(@__DIR__, "..", "..", "target", "release", "libsparse_ir_capi.$(dlext)")
+const libpath_debug = joinpath(@__DIR__, "..", "..", "target", "debug", "libsparse_ir_capi.$(dlext)")
+const libpath = isfile(libpath_release) ? libpath_release : libpath_debug
 
 # Error codes (compatible with libsparseir)
 const SPIR_COMPUTATION_SUCCESS = Int32(0)


### PR DESCRIPTION
## Summary
- Replace hardcoded `target/debug` library path in `test_julia.jl` with auto-detection
- Prefers `target/release` (matching documented build flow), falls back to `target/debug`
- Uses `joinpath(@__DIR__, ...)` for portable path resolution

## Test plan
- [ ] Build with `cargo build --release -p sparse-ir-capi` and verify `julia test_julia.jl` works
- [ ] Build with `cargo build -p sparse-ir-capi` (debug) and verify `julia test_julia.jl` works

Closes #179